### PR TITLE
The order of SCGI headers should be as specified.

### DIFF
--- a/main.go
+++ b/main.go
@@ -150,8 +150,14 @@ func receive(conn net.Conn) (*Response, error) {
 func defaultHeader(bodyLen int) []byte {
 	var dh []byte
 	defaultHeaderFields["CONTENT_LENGTH"] = strconv.Itoa(bodyLen)
-	for k, v := range defaultHeaderFields {
-		dh = append(dh, header(k, v)...)
+	order := []string{
+		"CONTENT_LENGTH",
+		"SCGI",
+		"REQUEST_METHOD",
+		"SERVER_PROTOCOL",
+	}
+	for _, k := range order {
+		dh = append(dh, header(k, defaultHeaderFields[k])...)
 	}
 	return dh
 }


### PR DESCRIPTION
Since Golang is randomizing the hash table entries, it's needed to pull the headers in a specific order to avoid random order of final headers.